### PR TITLE
Remove go.sum from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@
 *.out
 *.dll
 *.exe
-go.sum


### PR DESCRIPTION
`go.sum` file ensures the integrity of dependencies, thus cannot be ignored by `.gitignore` and should be uploaded to repository.